### PR TITLE
Update CodaLab Competitions to point to the new LISN server

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
             <div class="col-sm-6 competition-latest-list">
                  <div class="btn-group btn-group-justified" role="group" aria-label="...">
                       <div class="btn-group" role="group">
-                            <a role="button" class="btn" href="https://competitions.codalab.org">Competitions</a>
+                            <a role="button" class="btn" href="https://codalab.lisn.fr/">Competitions</a>
                       </div>
                 </div>
                 <p><strong>Enter an existing competition to solve challenging data problems, or host your own.</strong></p>


### PR DESCRIPTION
Hi,

The goal of this PR is simply to change the URL of the button `Competitions` of the landing page.

From https://competitions.codalab.org/ to https://codalab.lisn.fr/ (the new server)